### PR TITLE
added unfollow()

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,6 +102,10 @@ module.exports = function (db, opts) {
     lastDB.put(other, 0, cb)
   }
 
+  db.unfollow = function (other, cb) {
+    lastDB.del(other, cb)
+  }
+
   db.isFollowing = function (other, cb) {
     lastDB.get(other, cb)
   }


### PR DESCRIPTION
Somewhat naive approach

If the target is refollowed, lastDB needs to have the correct seq value restored. We might create a 'lst-cache' sublevel and make the following changes:

``` js
db.follow = function (other, cb) {
  lastCacheDB.get(other, function(err, entry) {
    if (err) return cb(err)
    lastDB.put(other, (entry) ? entry.value : 0, cb)
  })
}

db.unfollow = function (other, cb) {
  lastCache.get(other, function(err, entry) {
    if (err) return cb(err)
    lastCacheDB.put(other, entry.value, function(err) {
      if (err) return cb(err)
      lastDB.del(other, cb)
    })
  })
}
```
