### PR TITLE
set pull-stream dep to ~2.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "osenv": "~0.0.3",
     "proquint-": "~1.1.0",
     "pull-cat": "~1.1.5",
-    "pull-stream": "~2.24.1",
+    "pull-stream": "~2.24.0",
     "pull-paramap": "~1.1.1",
     "pull-delayed-sink": "~1.0.0",
     "pull-level": "~1.1.12",


### PR DESCRIPTION
This was giving me trouble with npm. The repo currently shows 2.24.0-- is that latest?
