### PR TITLE
updated feed.add() to output message and message hash, as documented

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,9 +90,9 @@ module.exports = function (db, opts) {
     //check that msg is valid (follows from end of database)
     //then insert into database.
     var n = 1
-    validation.validate(msg, function (err) {
+    validation.validate(msg, function (err, msg, hash) {
       if(--n) throw new Error('called twice')
-      cb && cb(err, msg, opts.hash(opts.codec.encode(msg)))
+      cb && cb(err, msg, hash)
     })
   }
 

--- a/test/feed.js
+++ b/test/feed.js
@@ -16,8 +16,10 @@ module.exports = function (opts) {
 
     var feed = ssb.createFeed(opts.keys.generate())
 
-    feed.add('msg', 'hello there!', function (err, msg) {
+    feed.add('msg', 'hello there!', function (err, msg, hash) {
       if(err) throw err
+      t.assert(!!msg)
+      t.assert(!!hash)
       pull(
         ssb.createFeedStream(),
         pull.collect(function (err, ary) {
@@ -43,10 +45,13 @@ module.exports = function (opts) {
 
     console.log('add 1'); console.log('add 2');
     var nDrains = 0, nAdds = 2;
-    feed.add('msg', 'hello there!', function (err, msg) {
+    feed.add('msg', 'hello there!', function (err, msg1, lasthash) {
       if(err) throw err
       function addAgain() {
-        feed.add('msg', 'message '+nDrains, function(err) {
+        feed.add('msg', 'message '+nDrains, function(err, msgX, hashX) {
+          t.equal(msgX.previous.toString('hex'), lasthash.toString('hex'))
+          console.log(msgX.previous.toString('hex'), lasthash.toString('hex'))
+          lasthash = hashX;
           nAdds++;
           console.log('add', nAdds);
           if (err) throw err;


### PR DESCRIPTION
It's not super efficient to rehash it like this, but the validator code doesnt have an obvious way to pass the computed hash onto the callback.
