### PR TITLE
validation now rejects messages larger than 1024 bytes

### DIFF
--- a/test/validation.js
+++ b/test/validation.js
@@ -141,6 +141,29 @@ module.exports = function (opts) {
 
 
   })
+
+  tape('too big', function (t) {
+    var keys = opts.keys.generate()
+    var id = opts.hash(keys.public)
+    var prev
+    ssb.add(
+      prev = create(keys, null, {type: 'init', public: keys.public}),
+      function (err) {
+        if(err) throw explain(err, 'init failed')
+
+        var str = ''
+        for (var i=0; i < 101; i++) str += '1234567890'
+        ssb.add(
+          prev = create(keys, 'msg', str, prev),
+          function (err) {
+            if(!err) throw 'too big was allowed'
+            console.log(err)
+            t.end()
+          }
+        )
+      }
+    )
+  })
 }
 
 if(!module.parent)

--- a/validation.js
+++ b/validation.js
@@ -38,6 +38,14 @@ module.exports = function (ssb, opts) {
   var validators = {}
 
   function validateSync (msg, prev, pub) {
+    // :TODO: is there a faster way to measure the size of this message?
+    //        would it be better to manually estimate it by crawling the obj structure?
+    var asJson = JSON.stringify(msg)
+    if (asJson.length > 1024) {
+      validateSync.reason = 'encoded message must not be larger than 1024 bytes'
+      return false
+    }
+
     var type = msg.content.type
     if(!isString(type)) {
       validateSync.reason = 'type property must be string'

--- a/validation.js
+++ b/validation.js
@@ -213,8 +213,9 @@ module.exports = function (ssb, opts) {
       }
       else if(prev.sequence >= next.sequence) {
         ssb.get(op.key, op.cb)
-      } else
-        throw new Error('should never happen - seq too high')
+      } else {
+        return op.cb(new Error('seq too high'))
+      }
     }
   }
 


### PR DESCRIPTION
https://github.com/ssbc/secure-scuttlebutt/issues/74

is there a better way to do this? would be great not to do a throwaway `JSON.stringify`