### PR TITLE
relatedMessages

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,32 @@ only stream messages with sequence numbers greater than `seq`.
 if `live` is true, the stream will be a
 [live mode](https://github.com/dominictarr/pull-level#example---reading)
 
+### SecureScuttlebutt#relatedMessages ({id: hash, rel: string?, count: false?, parent: false?}, cb)
+
+retrive the tree of messages related to `id`.
+This is ideal for collecting things like threaded replies.
+If `rel` is provided, only messages that link to the message with the given type are included.
+The output is a recursive structure like this:
+
+``` js
+{
+  key: <id>,
+  value: <msg>,
+  related: [
+    <recursive>,...
+  ],
+  //number of messages below this point. (when opts.count = true)
+  count: <int>,
+  //the message this message links to. this will not appear on the bottom level.
+  //(when opts.parent = true)
+  parent: <parent_id>
+}
+```
+
+If `count` option is true, then each message will contain a `count`
+it's decendant messages. If `parent` is true then each level will have 
+`parent`, the `id/key` of it's parent message.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -422,7 +422,6 @@ module.exports = function (db, opts) {
     }
 
     function count (msg) {
-      if(!opts.count) return msg
       if(!msg.related)
         return msg
       var c = 0
@@ -430,7 +429,7 @@ module.exports = function (db, opts) {
         if(opts.parent) _msg.parent = msg.key
         c += 1 + (count(_msg).count || 0)
       })
-      msg.count = c
+      if(opts.count) msg.count = c
       return msg
     }
 

--- a/test/related-messages.js
+++ b/test/related-messages.js
@@ -1,0 +1,171 @@
+'use strict'
+var tape     = require('tape')
+var level    = require('level-test')()
+var sublevel = require('level-sublevel/bytewise')
+var pull     = require('pull-stream')
+var cont     = require('cont')
+
+module.exports = function (opts) {
+
+  tape('simple', function (t) {
+
+    var db = sublevel(level('test-ssb-related', {
+      valueEncoding: opts.codec
+    }))
+
+    var ssb = require('../')(db, opts)
+
+    var alice = ssb.createFeed()
+    var bob = ssb.createFeed()
+    var charlie = ssb.createFeed()
+
+    alice.add({
+      type: 'post',
+      text: 'hello, world'
+    }, function (err, msg) {
+      if(err) throw err
+      console.log(msg)
+
+      bob.add({
+        type: 'post',
+        text: 'welcome!',
+        'parent': { msg: msg.key, rel: 'replies-to' }
+      }, function (err, msg2) {
+        if(err) throw err
+
+        ssb.relatedMessages({id: msg.key, count: true}, function (err, msgs) {
+
+          console.log(msgs)
+
+          t.deepEqual(msgs, {
+            key: msg.key, value: msg.value,
+            related: [
+              msg2
+            ],
+            count: 1
+          })
+
+          t.end()
+        })
+      })
+    })
+  })
+
+  tape('deeper', function (t) {
+
+    var db = sublevel(level('test-related2', {
+      valueEncoding: opts.codec
+    }))
+
+    var ssb = require('../')(db, opts)
+
+    var alice = ssb.createFeed()
+    var bob = ssb.createFeed()
+    var charlie = ssb.createFeed()
+
+
+    alice.add({
+      type: 'post',
+      text: 'hello, world'
+    }, function (err, msg) {
+      if(err) throw err
+      console.log(msg)
+
+      bob.add({
+        type: 'post',
+        text: 'welcome!',
+        'parent': { msg: msg.key, rel: 'replies-to' }
+      }, function (err, msg2) {
+        if(err) throw err
+
+        charlie.add({
+          type: 'post',
+          text: 'hey hey',
+          'parent': { msg: msg2.key, rel: 'replies-to' }
+        }, function (err, msg3) {
+
+          ssb.relatedMessages({id: msg.key, count: true}, function (err, msgs) {
+
+            console.log(JSON.stringify(msgs, null, 2))
+
+            t.deepEqual(msgs, {
+              key: msg.key, value: msg.value,
+              related: [
+                {
+                  key: msg2.key, value: msg2.value,
+                  related: [
+                    msg3
+                  ],
+                  count: 1
+                }
+              ],
+              count: 2
+            })
+
+            t.end()
+
+          })
+        })
+      })
+    })
+  })
+  tape('shallow', function (t) {
+
+    var db = sublevel(level('test-related3', {
+      valueEncoding: opts.codec
+    }))
+
+    var ssb = require('../')(db, opts)
+
+    var alice = ssb.createFeed()
+    var bob = ssb.createFeed()
+    var charlie = ssb.createFeed()
+
+
+    alice.add({
+      type: 'post',
+      text: 'hello, world'
+    }, function (err, msg1) {
+      if(err) throw err
+
+
+      cont.para([
+        bob.add({
+          type: 'post',
+          text: 'welcome!',
+          'parent': { msg: msg1.key, rel: 'replies-to' }
+        }),
+        charlie.add({
+          type: 'post',
+          text: 'hey hey',
+          'parent': { msg: msg1.key, rel: 'replies-to' }
+        })
+      ]) (function (err, ary) {
+        if(err) throw err
+        var msg2 = ary[0]
+        var msg3 = ary[1]
+
+        ssb.relatedMessages({id: msg1.key, count: true}, function (err, msgs) {
+
+          console.log(JSON.stringify(msgs, null, 2))
+
+          t.deepEqual(msgs, {
+            key: msg1.key, value: msg1.value,
+            related: [
+              msg2, msg3
+            ],
+            count: 2
+          })
+
+          t.end()
+        })
+      })
+    })
+  })
+
+
+}
+
+if(!module.parent)
+  module.exports(require('../defaults'))
+


### PR DESCRIPTION
Basically the same as phoenix's `getThread`, except as a query instead of as a view/index.
It is simple to rebuild this on demand because we already have an index of links within messages, so it's just a few calls to get the "replies".

By passing in a `rel` type, you get only messages that reply by that type. Also supported are `count` and `parent` options, but they are off by default.

This can be used to implement comment threading, but also many other types of recursive structures based on message links.

I added api documentation, although I notice that the other documentation is kinda out of date.