### PR TITLE
fix: validation pipeline now drains after a validation error

### DIFF
--- a/validation.js
+++ b/validation.js
@@ -209,12 +209,14 @@ module.exports = function (ssb, opts) {
         }
         else {
           op.cb(new Error(validateSync.reason))
+          drain()
         }
       }
       else if(prev.sequence >= next.sequence) {
         ssb.get(op.key, op.cb)
       } else {
-        return op.cb(new Error('seq too high'))
+        op.cb(new Error('seq too high'))
+        drain()
       }
     }
   }


### PR DESCRIPTION
We were experiencing long delays in the `feed.add()` function for reasons unknown (https://github.com/ssbc/phoenix/issues/299#issuecomment-73179046). Turns out it was because the validation pipeline was failing to resume processing after a message was rejected. Adding some `drain()` calls solved the issue.

Closes https://github.com/ssbc/phoenix/issues/299