### PR TITLE
make source streams abortable

### DIFF
--- a/index.js
+++ b/index.js
@@ -285,13 +285,15 @@ module.exports = function (db, opts) {
       _keys    = opts.keys
       _values  = opts.values
     }
+
     return pull(
       pl.read(clockDB, {
         gte:  [id, seq],
         lte:  [id, MAX_INT],
         live: live,
         keys: false,
-        sync: opts && opts.sync
+        sync: opts && opts.sync,
+        onAbort: opts && opts.onAbort
       }),
       paramap(function (key, cb) {
         if(key.sync) return cb(null, key)
@@ -441,7 +443,8 @@ module.exports = function (db, opts) {
           live: opts.live,
           reverse: opts.reverse,
           limit: opts.limit,
-          sync: opts.sync
+          sync: opts.sync,
+          onAbort: opts.onAbort
         }),
         pull.map(function (op) {
           if(op.sync) return op

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "monotonic-timestamp": "~0.0.8",
     "pull-cat": "~1.1.5",
     "pull-level": "~1.3.0",
-    "pull-paramap": "~1.1.1",
+    "pull-paramap": "~1.1.2",
     "pull-stream": "~2.24.1",
     "pull-switch": "~2.0.0",
     "ssb-msgs": "~3.0.0",
@@ -37,7 +37,8 @@
     "multicb": "~0.0.2",
     "hexpp": "~1.1.3",
     "pull-randomly-split": "~1.0.4",
-    "explain-error": "~1.0.0"
+    "explain-error": "~1.0.0",
+    "pull-abortable": "~4.1.0"
   },
   "scripts": {
     "prepublish": "npm ls && npm test",

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "ltgt": "~2.0.0",
     "monotonic-timestamp": "~0.0.8",
     "pull-cat": "~1.1.5",
-    "pull-level": "~1.3.0",
+    "pull-level": "~1.4.0",
     "pull-paramap": "~1.1.2",
     "pull-stream": "~2.24.1",
     "pull-switch": "~2.0.0",
     "ssb-msgs": "~3.0.0",
     "explain-error": "~1.0.1",
-    "ssb-keys": "~0.6",
-    "ssb-feed": "~0.0.1",
+    "ssb-keys": "~1.0.1",
+    "ssb-feed": "~0.1.0",
     "mynosql": "~2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
this brings in some fixes through out pull-level and pull-paramap to make streams clean themselves up properly,
working towards memory leak problems. Since this adds onAbort to createHistoryStream it's a minor change.