### PR TITLE
Update links and link-indexing to use sigils

### DIFF
--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -56,7 +56,7 @@ module.exports = function (opts) {
       }, [alice.public, bob.public]
     ), function (err, msg) {
       feed.add(ssbKeys.box({
-          type: 'secret', post: 'wow', reply: {msg: msg.key}
+          type: 'secret', post: 'wow', reply: msg.key
         }, [alice.public, bob.public]
       ), function (err, msg2) {
 
@@ -82,7 +82,7 @@ module.exports = function (opts) {
       }, [alice.public, bob.public]
     ), function (err, msg) {
       feed.add(ssbKeys.box({
-          type: 'secret', post: 'wow', reply: {msg: msg.key}
+          type: 'secret', post: 'wow', reply: msg.key
         }, [alice.public, bob.public]
       ), function (err, msg2) {
         ssb.relatedMessages({key: msg.key, rel: 'reply'},

--- a/test/linktypes.js
+++ b/test/linktypes.js
@@ -66,7 +66,7 @@ module.exports = function (opts) {
           cont.series([
             function (cb) {
               all(ssb.links({
-                dest: msg.key, type: 'msg', rel: 'reply',
+                dest: msg.key, rel: 'reply',
                 meta: false, keys: false, values: true
               })) (function (err, ary) {
                 if(err) throw err
@@ -78,7 +78,7 @@ module.exports = function (opts) {
             },
             function (cb) {
               all(ssb.links({
-                dest: msg.key, rel: 'reply', type: 'msg',
+                dest: msg.key, rel: 'reply',
                 keys: true, meta: false, values: true
               }))
                 (function (err, ary) {
@@ -88,7 +88,7 @@ module.exports = function (opts) {
                 })
             },
             function (cb) {
-              all(ssb.links({dest: msg.key, rel: 'reply', type: 'msg', values: true}))
+              all(ssb.links({dest: msg.key, rel: 'reply', values: true}))
                 (function (err, ary) {
                   if(err) throw err
                   t.deepEqual(sort(ary), sort([
@@ -132,10 +132,10 @@ module.exports = function (opts) {
     }) (function (err, f) {
 
       cont.para({
-        alice:  all(ssb.links({source: alice.id, type: 'feed'})),
-        bob:    all(ssb.links({source: bob.id, type: 'feed'})),
-        _alice: all(ssb.links({dest: alice.id, type: 'feed'})),
-        _carol: all(ssb.links({dest: carol.id, type: 'feed'}))
+        alice:  all(ssb.links({source: alice.id, dest: '@'})),
+        bob:    all(ssb.links({source: bob.id, dest: 'feed'})),
+        _alice: all(ssb.links({dest: alice.id, source: '@'})),
+        _carol: all(ssb.links({dest: carol.id, source: 'feed'}))
       }) (function (err, r) {
 
         console.log({
@@ -176,7 +176,6 @@ module.exports = function (opts) {
           ssb.links({
             source: a,
             dest: b,
-            type: 'feed',
             rel: 'follow'
           }),
           pull.collect(function (_, ary) {
@@ -215,8 +214,7 @@ module.exports = function (opts) {
       poke: bob.id
     }, function (err) {
       all(ssb.links({
-        source: alice.id, dest: bob.id, type: 'feed',
-        values: true
+        source: alice.id, dest: bob.id, values: true
       }))
       (function (err, ary) {
         if(err) throw err

--- a/test/linktypes.js
+++ b/test/linktypes.js
@@ -132,10 +132,10 @@ module.exports = function (opts) {
     }) (function (err, f) {
 
       cont.para({
-        alice:  all(ssb.links({source: alice.id, type:'feed', rel:'follow'})),
-        bob:    all(ssb.links({source: bob.id, type: 'feed', rel: 'follow'})),
-        _alice: all(ssb.links({dest: alice.id, rel:'follow', type: 'feed'})),
-        _carol: all(ssb.links({dest: carol.id, rel: 'follow', type: 'feed'}))
+        alice:  all(ssb.links({source: alice.id, type: 'feed'})),
+        bob:    all(ssb.links({source: bob.id, type: 'feed'})),
+        _alice: all(ssb.links({dest: alice.id, type: 'feed'})),
+        _carol: all(ssb.links({dest: carol.id, type: 'feed'}))
       }) (function (err, r) {
 
         console.log({

--- a/test/linktypes.js
+++ b/test/linktypes.js
@@ -53,12 +53,12 @@ module.exports = function (opts) {
     alice.add('msg', 'hello world', function (err, msg) {
       if(err) throw err
       bob.add('msg', {
-        reply: {msg: msg.key},
+        reply: msg.key,
         text: 'okay then'
       }, function (err, reply1) {
         if(err) throw err
         carol.add('msg', {
-          reply: {msg: msg.key},
+          reply: msg.key,
           text: 'whatever'
         }, function (err, reply2) {
           if(err) throw err
@@ -118,7 +118,7 @@ module.exports = function (opts) {
 
     function follow (a, b) {
       return function (cb) {
-        a.add('follow', {follow:{feed: b.id}}, function (err, msg) {
+        a.add('follow', {follow: b.id}, function (err, msg) {
           cb(err, msg.key)
         })
       }
@@ -212,7 +212,7 @@ module.exports = function (opts) {
   tape('scan links with unknown rel', function (t) {
     alice.add({
       type: 'poke',
-      poke: {feed: bob.id}
+      poke: bob.id
     }, function (err) {
       all(ssb.links({
         source: alice.id, dest: bob.id, type: 'feed',
@@ -224,8 +224,8 @@ module.exports = function (opts) {
         t.deepEqual(ary.map(function (e) {
           return e.value.content
         }), [
-          {type: 'follow', follow: {feed: bob.id}},
-          {type: 'poke', poke: {feed: bob.id}},
+          {type: 'follow', follow: bob.id},
+          {type: 'poke', poke: bob.id},
         ])
         t.end()
 

--- a/test/rebuild.js
+++ b/test/rebuild.js
@@ -49,13 +49,13 @@ module.exports = function (opts) {
         console.log(msg)
 
         bob.add('msg', {
-          reply: {msg: msg.key},
+          reply: msg.key,
           content: 'okay then'
         }, function (err, r1) {
           reply1 = r1
           console.log(reply1)
           carol.add('msg', {
-            reply: {msg: msg.key},
+            reply: msg.key,
             content: 'whatever'
           }, function (err, r2) {
             reply2 = r2

--- a/test/related-messages.js
+++ b/test/related-messages.js
@@ -32,7 +32,7 @@ module.exports = function (opts) {
       bob.add({
         type: 'post',
         text: 'welcome! 1',
-        'replies-to': { msg: msg.key }
+        'replies-to': msg.key
       }, function (err, msg2) {
         if(err) throw err
 
@@ -66,14 +66,14 @@ module.exports = function (opts) {
       bob.add({
         type: 'post',
         text: 'welcome! 2',
-        'replies-to': { msg: msg.key }
+        'replies-to': msg.key
       }, function (err, msg2) {
         if(err) throw err
 
         charlie.add({
           type: 'post',
           text: 'hey hey 2',
-          'replies-to': { msg: msg2.key }
+          'replies-to': msg2.key
         }, function (err, msg3) {
 
           ssb.relatedMessages({id: msg.key, count: true}, function (err, msgs) {
@@ -115,12 +115,12 @@ module.exports = function (opts) {
         bob.add({
           type: 'post',
           text: 'welcome! 3',
-          'replies-to': { msg: msg1.key }
+          'replies-to': msg1.key
         }),
         charlie.add({
           type: 'post',
           text: 'hey hey 3',
-          'replies-to': { msg: msg1.key }
+          'replies-to': msg1.key
         })
       ]) (function (err, ary) {
         if(err) throw err
@@ -156,7 +156,7 @@ module.exports = function (opts) {
       bob.add({
         type: 'post',
         text: 'welcome! 4',
-        'replies-to': { msg: msg.key }
+        'replies-to': msg.key
       }, function (err, msg2) {
         if(err) throw err
 

--- a/test/validation.js
+++ b/test/validation.js
@@ -33,7 +33,7 @@ module.exports = function (opts) {
       validate(msg, function (err) {
         console.log('HELLO', opts.hash('HELLLO'))
         if(_msg)
-          t.deepEqual(opts.hash(opts.codec.encode(_msg)), msg.previous)
+          t.deepEqual('%'+opts.hash(opts.codec.encode(_msg)), msg.previous)
         _msg = msg
         if(err) throw err
         if(msg.sequence === 3)


### PR DESCRIPTION
I ended up changing how the link indexing works in this. All links create the same 3 indexes, now:

 1. forward, from message author to link target
 2. backward, from link target to message author
 3. backward, from link target to message

This changes the `links()` function such that, if `type == msg`, then you'll get entries from index 3, and if `type == feed` then you'll get entries from index 1 and 2. `Type: msg` is now the default.

This change makes it possible to get links between feeds and messages/blobs.

However, this changes the meaning of the `type` parameter in `links()`. Instead of meaning, "give me links of that type," it's saying, "give me links *between* those types."