### PR TITLE
update createFeedStream range params to operate on timestaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,6 +221,9 @@ module.exports = function (db, opts, keys) {
   //TODO: eventually, this should filter out authors you do not follow.
   db.createFeedStream = function (opts) {
     opts = stdopts(opts)
+    ltgt.toLtgt(opts, opts, function (value) {
+      return [value, LO]
+    }, LO, HI)
     var _keys = opts.keys
     var _values = opts.values
     opts.keys = false


### PR DESCRIPTION
I noticed that the gt/gte/lt/lte params were operating on the index without modification. Well, the feed index looks like `[ts, author]` so there's not much reason to query against that. This PR makes those params query against just `ts`