### PR TITLE
rewrite links

### DIFF
--- a/index.js
+++ b/index.js
@@ -440,15 +440,17 @@ module.exports = function (db, opts, keys) {
           dest: op.key[back?1:3],
           key: op.key[5]
         }
-      }),      // apply any filters
+      }),
+      // in case source and dest are known but not rel,
+      // this will scan all links from the source
+      // and filter out those to the dest. not efficient
+      // but probably a rare query.
       pull.filter(function (data) {
         if(rel && rel !== data.rel) return false
         if(!testLink(data.dest, dst)) return false
         if(!testLink(data.source, src)) return false
         return true
       }),
-      //handle case where source and dest are known but not rel.
-      //this will scan all links from the source. not so efficient.
       ! opts.values
       ? pull.map(function (op) {
           return format(opts, op, op.key, null)

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -63,7 +63,7 @@ module.exports = function (opts) {
           ssb.links({dest: msg.key, type: 'msg', keys: false}),
           pull.collect(function (err, ary) {
             t.deepEqual(ary, [{
-              source: msg2.key, rel: 'reply',
+              source: msg2.value.author, rel: 'reply',
               dest: msg.key
             }])
             t.end()

--- a/test/links.js
+++ b/test/links.js
@@ -1,0 +1,99 @@
+'use strict'
+
+var tape       = require('tape')
+var level      = require('level-test')()
+var sublevel   = require('level-sublevel/bytewise')
+var pull       = require('pull-stream')
+var ssbKeys    = require('ssb-keys')
+var createFeed = require('ssb-feed')
+var cont       = require('cont')
+
+module.exports = function (opts) {
+  var create = require('ssb-feed/util').create
+
+  var db = sublevel(level('test-ssb-feed', {
+    valueEncoding: opts.codec
+  }))
+
+  var db = require('../')(db, opts)
+
+  var alice = db.createFeed(opts.generate())
+  var bob = db.createFeed(opts.generate())
+
+  var msgs = []
+
+  tape('initialize', function (t) {
+
+    cont.para([
+      alice.add({type: 'yo!', yo: alice.id}),
+      alice.add({type: 'contact', follow: bob.id, okay: true}),
+      bob.add({type: 'poke', poke: alice.id}),
+      alice.add({type: 'poke', poke: alice.id})
+    ])(function (err, _msgs) {
+      msgs = _msgs
+      t.notOk(err)
+      bob.add({
+        type: 'post', mentions: [msgs[2].key], text: 'okay then'
+      }, function (err, msg) {
+        msgs.push(msg)
+        t.notOk(err); t.end()
+      })
+    })
+
+  })
+
+
+  tape('query only rel type', function (t) {
+    
+    pull(
+      db.links({rel: 'yo'}),
+      pull.through(function (data) {
+        t.ok(data.key)
+        delete data.key
+      }),
+      pull.collect(function (err, ary) {
+        t.notOk(err)
+        t.deepEqual(ary, [{source: alice.id, rel: 'yo', dest: alice.id}])
+        console.log(ary)
+        t.end()
+      })
+    )
+  })
+
+  function createTest (t) {
+    return function test(name, query, results) {
+      t.test(name, function (t) {
+        pull(
+          db.links(query),
+          pull.collect(function (err, ary) {
+            t.notOk(err)
+            t.equal(ary.length, results.length)
+            t.deepEqual(ary, results)
+            t.end()
+          })
+        )
+      })
+    }
+  }
+
+  tape('query by dest', function (t) {
+    var test = createTest(t)
+    var mention = {
+      source: bob.id,
+      rel: 'mentions',
+      dest: msgs[2].key,
+      key: msgs[4].key,
+    }
+    test('equal, query dest: %',
+      {dest: '%'}, [mention])
+    test('equal, query exact dest: %...',
+      {dest: msgs[2].key}, [mention])
+    test('equal, query dest: %..., rel: mentions',
+      {dest: msgs[2].key, rel: 'mentions'}, [mention])
+  })
+
+}
+
+if(!module.parent)
+  module.exports(require('../defaults'))
+

--- a/test/linktypes.js
+++ b/test/linktypes.js
@@ -39,7 +39,6 @@ module.exports = function (opts) {
 
   function sortTS (ary) {
     return ary.sort(function (a, b) {
-      console.log(a, b)
       return (
           a.timestamp - b.timestamp
         || typewise(a.key, b.key)
@@ -70,8 +69,6 @@ module.exports = function (opts) {
                 meta: false, keys: false, values: true
               })) (function (err, ary) {
                 if(err) throw err
-                console.log(ary)
-                console.log(reply1, reply2)
                 t.deepEqual(sortTS(ary), sortTS([reply1.value, reply2.value]))
                 cb()
               })
@@ -93,12 +90,12 @@ module.exports = function (opts) {
                   if(err) throw err
                   t.deepEqual(sort(ary), sort([
                     {
-                      source: reply1.key, rel: 'reply',
+                      source: reply1.value.author, rel: 'reply',
                       dest: msg.key, key: reply1.key,
                       value: reply1.value
                     },
                     {
-                      source: reply2.key, rel: 'reply',
+                      source: reply2.value.author, rel: 'reply',
                       dest: msg.key, key: reply2.key,
                       value: reply2.value
                     }


### PR DESCRIPTION
After noticing that links was not handling some cases the other day, (in particular, queries where not filtered by rel at all) I rewrote links.

This bug was introduced by upgrading links to use sigils.
https://github.com/ssbc/secure-scuttlebutt/pull/125

This makes a breaking change: if a `source` (or source sigil) was not provided,
previously it defaults to the message as the source. but the author as the source makes more sense. You can get the message easily - from the `.key`
property (and have links return you the whole message with values: true)
Making source always be a feed is also more consistent with the query
input. It doesn't really make sense to query the source as a message
anyway.

This did mean changing the tests, but I grepped through patchwork and scuttlebot and we havn't actually used a source value in a links query (not in the product code, there are examples in the tests)

there are some times when you might want to do so - like, to check if Alice has blocked Bob, you could query `links({source: alice, dest: bob, rel: follows})` but in the cases we are doing that we have an in memory structure, so this change wouldn't actually break any code.