### PR TITLE
Ignore missing root message in relatedMessages()

### DIFF
--- a/index.js
+++ b/index.js
@@ -483,12 +483,15 @@ module.exports = function (db, opts, keys) {
     var msgs = {key: key, value: null}
     db.get(key, function (err, msg) {
       msgs.value = msg
+      if (err && err.notFound)
+        err = null // ignore not found
       done(err)
     })
 
     related(msgs)
 
     function related (msg) {
+      if (n<0) return
       n++
       all(db.links({dest: msg.key, rel: opts.rel, keys: true, values:true, meta: false, type:'msg'}))
       (function (err, ary) {

--- a/test/related-messages.js
+++ b/test/related-messages.js
@@ -178,6 +178,54 @@ module.exports = function (opts) {
   })
 
 
+  tape('missing root message', function (t) {
+
+    var msg1Key = '%HH88p+bzbBxVdse9gihlylVvM7uqswKXxcQfYCR5DGU=.sha256'
+    // alice.add({
+    //   type: 'post',
+    //   text: 'hello, world 2'
+    // }, function (err, msg) {
+    //   if(err) throw err
+    //   console.log(msg)
+
+      bob.add({
+        type: 'post',
+        text: 'welcome! 2',
+        'replies-to': msg1Key
+      }, function (err, msg2) {
+        if(err) throw err
+
+        charlie.add({
+          type: 'post',
+          text: 'hey hey 2',
+          'replies-to': msg2.key
+        }, function (err, msg3) {
+
+          ssb.relatedMessages({id: msg1Key, count: true}, function (err, msgs) {
+
+            console.log(JSON.stringify(msgs, null, 2))
+
+            t.deepEqual(msgs, {
+              key: msg1Key, value: undefined,
+              related: [
+                {
+                  key: msg2.key, value: msg2.value,
+                  related: [
+                    msg3
+                  ],
+                  count: 1
+                }
+              ],
+              count: 2
+            })
+
+            t.end()
+
+          })
+        })
+      })
+    })
+  // })
 
 }
 


### PR DESCRIPTION
Prior to this PR, if you ran `relatedMessages()` on a msg-id that's not present†, but which does have present messages linking to the root, then `relatedMessages()` would call the cb() with an error message, and, in some cases, would call the cb *twice*, resulting in a backend crash (cb called twice error).

This PR does two things:
 - Guards against the double cb-call
 - Ignores a root-not-found error, so that the rest of the thread can be assembled

† present: saved in the local database