### PR TITLE
remove mynosql

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,9 @@ var assert    = require('assert')
 var ltgt      = require('ltgt')
 var mlib      = require('ssb-msgs')
 var explain   = require('explain-error')
-var mynosql   = require('mynosql')
 var pdotjson  = require('./package.json')
 var createFeed = require('ssb-feed')
 var cat       = require('pull-cat')
-var mynosql   = require('mynosql')
 var ssbref    = require('ssb-ref')
 var ssbKeys   = require('ssb-keys')
 
@@ -56,7 +54,6 @@ function getVMajor () {
 }
 
 module.exports = function (db, opts, keys) {
-  db = mynosql(db)
   var sysDB   = db.sublevel('sys')
   var logDB   = db.sublevel('log')
   var feedDB  = db.sublevel('fd')
@@ -101,11 +98,10 @@ module.exports = function (db, opts, keys) {
     // this will be used to pass to plugins which
     // must create their indexes asyncly.
 
-// local time is now handled by 
-//    add({
-//      key: localtime, value: id,
-//      type: 'put', prefix: logDB
-//    })
+    add({
+      key: localtime, value: id,
+      type: 'put', prefix: logDB
+    })
 
     indexMsg(add, localtime, id, msg)
 
@@ -530,3 +526,7 @@ module.exports = function (db, opts, keys) {
 
   return db
 }
+
+
+
+

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "level-sublevel": "^6.5.2",
     "ltgt": "~2.0.0",
     "monotonic-timestamp": "~0.0.8",
-    "mynosql": "~2.3.1",
     "pull-cat": "~1.1.5",
     "pull-level": "~1.4.0",
     "pull-paramap": "~1.1.3",
@@ -58,3 +57,4 @@
     "files": "test/defaults.js"
   }
 }
+


### PR DESCRIPTION
mynosql was a cute idea, but streamviews are much better.
we never actually used mynosql features, so it's easy to remove it.
I think we can consider this a patch.