### PR TITLE
Fixed error "Cannot find module 'typewiselite'"

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ var ssbref    = require('ssb-ref')
 var ssbKeys   = require('ssb-keys')
 var Live      = require('pull-live')
 var Notify    = require('pull-notify')
-var compare   = require('typewiselite')
 
 var Validator = require('ssb-feed/validator')
 
@@ -416,7 +415,7 @@ module.exports = function (db, opts, keys) {
 
   function linksOpts (opts) {
     if(!opts) throw new Error('opts *must* be provided')
-    
+
     if(  !(opts.values === true)
       && !(opts.meta !== false)
       && !(opts.keys !== false)


### PR DESCRIPTION
After 
```
npm install ssb-patchwork -g
patchwork
```
Got the error
```
[CFG] Password: NO.
[CFG] TLS: NO.
[CFG] Remote Access: NO.
Patchwork - Copyright (C) 2015-2016 Secure Scuttlebutt Consortium
This program comes with ABSOLUTELY NO WARRANTY.
This is free software, and you are welcome to redistribute it under certain conditions (GPL-3.0).

Starting...
module.js:339
    throw err;
    ^

Error: Cannot find module 'typewiselite'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (/Users/glen/.nvm/versions/node/v4.2.2/lib/node_modules/ssb-patchwork/node_modules/scuttlebot/node_modules/secure-scuttlebutt/index.js:19:17)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
```

Looks like it was an accidental require since `compare` is overridden by a function later in the file anyway. 