### PR TITLE
Fix realtime links

### DIFF
--- a/index.js
+++ b/index.js
@@ -477,7 +477,7 @@ module.exports = function (db, opts, keys) {
         })
       : paramap(function (op, cb) {
           if(op._value)
-            return cb(null, opts.props, op, op.key, op._value)
+            return cb(null, format(opts.props, op, op.key, op._value))
           db.get(op.key, function (err, msg) {
             if(err) return cb(err)
             cb(null, format(opts.props, op, op.key, msg))

--- a/test/links.js
+++ b/test/links.js
@@ -121,6 +121,24 @@ module.exports = function (opts) {
     )
   })
 
+
+  tape('live link values', function (t) {
+    var links = []
+    pull(
+      db.links({old: false, live: true, values: true}),
+      pull.drain(links.push.bind(links))
+    )
+
+    alice.publish({type: 'foo', foo: bob.id}, function (err, msg) {
+      t.error(err, 'publish')
+      t.deepEqual(links, [
+        {key: msg.key, value: msg.value,
+          source: alice.id, dest: bob.id, rel: 'foo'}
+      ])
+      t.end()
+    })
+  })
+
 }
 
 if(!module.parent)


### PR DESCRIPTION
Turns out that #152 didn't fix what it was supposed to. The changed code wasn't covered by tests, so I didn't notice that the fix was not correct. The code path that uses `_value` is activated using `ssb.links({values: true, live: true, ...})`. Here I've corrected the fix and added a test to cover it.