### PR TITLE
Add missing dependency to package.json file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/ssbc/secure-scuttlebutt.git"
   },
   "dependencies": {
+    "bytewise": "^1.1.0",
     "cont": "~1.0.0",
     "deep-equal": "~0.2.1",
     "explain-error": "~1.0.1",


### PR DESCRIPTION
This change adds NPM package that is used but not declared as dependency
to `dependencies` section of `package.json` file.

Patchwork fails to start without this change.
