### PR TITLE
Replace await with wait

### DIFF
--- a/follower.js
+++ b/follower.js
@@ -17,8 +17,8 @@ module.exports = function (_db, path, version, map) {
     return Level(path, {keyEncoding: bytewise, valueEncoding: 'json'})
   }
 
-  function await(ready) {
-    _db.seen.await(function () {
+  function wait(ready) {
+    _db.seen.wait(function () {
       if(_db.seen.get() === since) return ready()
       waiting.push({ts: _db.seen.get(), cb: ready})
     })
@@ -103,17 +103,17 @@ module.exports = function (_db, path, version, map) {
   return {
     get: function (key, cb) {
       //wait until the log has been processed up to the current point.
-      await(function () {
+      wait(function () {
         db.get(key, cb)
       })
     },
-    await: await,
+    wait: wait,
     read: function (opts) {
       opts = opts || {}
       if(since === _db.seen.get()) return pl.read(db, opts)
 
       var source = defer.source()
-      await(function () {
+      wait(function () {
         source.resolve(pl.read(db, opts))
       })
       return source

--- a/index.js
+++ b/index.js
@@ -75,17 +75,17 @@ module.exports = function (db, opts, keys, path) {
 
   var realtime = Notify()
 
-  var await = u.await()
-  var set = await.set
-  await.set = null
+  var wait = u.wait()
+  var set = wait.set
+  wait.set = null
   var waiting = []
-  db.seen = await
+  db.seen = wait
   db.post(function (op) {
-    set(Math.max(op.ts || op.timestamp, await.get()||0))
+    set(Math.max(op.ts || op.timestamp, wait.get()||0))
   })
 
   peek.last(logDB, {keys: true}, function (err, key) {
-    set(Math.max(key || 0, await.get()||0))
+    set(Math.max(key || 0, wait.get()||0))
   })
 
   db.pre(function (op, _add, _batch) {
@@ -128,10 +128,10 @@ module.exports = function (db, opts, keys, path) {
     }
 
     var m = 4
-    feedDB.await(next2)
-    clockDB.await(next2)
-    lastDB.await(next2)
-    indexDB.await(next2)
+    feedDB.wait(next2)
+    clockDB.wait(next2)
+    lastDB.wait(next2)
+    indexDB.wait(next2)
 
     function next2 () {
       if(ended) return

--- a/util.js
+++ b/util.js
@@ -23,7 +23,7 @@ exports.format = msgFmt
 exports.lo = null
 exports.hi = undefined
 
-exports.await = function () {
+exports.wait = function () {
   var waiting = [], value
   return {
     get: function () { return value },
@@ -32,7 +32,7 @@ exports.await = function () {
       while(waiting.length)
         waiting.shift()(null, value)
     },
-    await: function (cb) {
+    wait: function (cb) {
       if(value !== undefined) cb(null, value)
       else waiting.push(cb)
     }


### PR DESCRIPTION
`await` is a reserved word, and is disallowed by recent JavaScript parsers, such as Babylon. This has nothing to do with strict mode.