### PR TITLE
progress bar enabling api

### DIFF
--- a/test/migration.js
+++ b/test/migration.js
@@ -20,7 +20,7 @@ tape('generate fake feed', function (t) {
     }
   }, ssbKeys.generate())
 
-  var l = 100000
+  var l = 10000
   while(l--)
     feed.add({type: 'test', text:'hello1', l: l}, function () {})
 
@@ -85,7 +85,24 @@ tape('migrate', function (t) {
 
 })
 
+tape('progress looks right on empty database', function (t) {
 
+  var db = sublevel(level('/tmp/test-ssb-feed_'+Date.now(), {
+    valueEncoding: require('../codec')
+  }))
 
+  var flume = require('../db')('/tmp/test-ssb-migration_'+Date.now())
+
+  flume.ready(function (b) {
+    if(b) {
+      console.log('ready?', flume.progress)
+      t.equal(flume.progress.ratio, 1)
+      t.end()
+    }
+  })
+
+  require('../legacy')(db, flume)
+
+})
 
 

--- a/test/migration.js
+++ b/test/migration.js
@@ -1,0 +1,91 @@
+var createFeed = require('ssb-feed')
+var ssbKeys = require('ssb-keys')
+var timestamp = require('monotonic-timestamp')
+var level = require('level')
+var sublevel = require('level-sublevel')
+var latest = {}, log = [], db
+
+var tape = require('tape')
+
+tape('generate fake feed', function (t) {
+  var start = Date.now()
+  var feed = createFeed({
+    getLatest: function (id, cb) {
+      cb(null, latest[id])
+    },
+    add: function (msg, cb) {
+      latest[msg.author] = {key: '%'+ssbKeys.hash(JSON.stringify(msg, null, 2)), value: msg}
+      log.push(msg)
+      cb()
+    }
+  }, ssbKeys.generate())
+
+  var l = 100000
+  while(l--)
+    feed.add({type: 'test', text:'hello1', l: l}, function () {})
+
+  console.log('generate', Date.now() - start)
+  t.end()
+})
+
+tape('populate legacy database', function (t) {
+  var start = Date.now()
+  db = sublevel(level('/tmp/test-ssb-feed_'+Date.now(), {
+    valueEncoding: require('../codec')
+  }))
+
+  require('../legacy')(db)
+
+  ;(function next () {
+    var batch = log.splice(0, 1000)
+    db.batch(batch.map(function (msg) {
+      var key = '%'+ssbKeys.hash(JSON.stringify(msg, null, 2))
+      return {
+        key: key,
+        value: {
+          key: key, value: msg, timestamp: +timestamp()
+        },
+        type: 'put'
+      }
+    }), function (err) {
+      if(log.length) {
+        console.log(log.length)
+        setTimeout(next)
+      }
+      else {
+        console.log('legacy-write', Date.now() - start)
+        t.end()
+      }
+    })
+  })()
+
+})
+
+tape('migrate', function (t) {
+  var start = Date.now()
+  var flume = require('../db')('/tmp/test-ssb-migration_'+Date.now())
+
+  var int = setInterval(function () {
+    console.log(flume.progress)
+  },100)
+
+  flume.ready(function (isReady) {
+    if(isReady) {
+      console.log('ready!', flume.since.value)
+      console.log(flume.progress)
+      console.log('migrate', Date.now() - start)
+      clearInterval(int)
+      t.equal(flume.progress.current, flume.progress.target)
+      t.equal(flume.progress.ratio, 1)
+      t.end()
+    }
+  })
+
+  require('../legacy')(db, flume)
+
+})
+
+
+
+
+

--- a/test/migration.js
+++ b/test/migration.js
@@ -76,7 +76,6 @@ tape('migrate', function (t) {
       console.log('migrate', Date.now() - start)
       clearInterval(int)
       t.equal(flume.progress.current, flume.progress.target)
-      t.equal(flume.progress.ratio, 1)
       t.end()
     }
   })
@@ -90,19 +89,25 @@ tape('progress looks right on empty database', function (t) {
   var db = sublevel(level('/tmp/test-ssb-feed_'+Date.now(), {
     valueEncoding: require('../codec')
   }))
-
+  
   var flume = require('../db')('/tmp/test-ssb-migration_'+Date.now())
 
   flume.ready(function (b) {
     if(b) {
       console.log('ready?', flume.progress)
-      t.equal(flume.progress.ratio, 1)
-      t.end()
+      t.ok(flume.progress, 'progress object is defined')
+      t.notOk(flume.progress.migration, 'progress.migration is undefined')
+      setTimeout(function () {
+        t.equal(
+          flume.progress.indexes.current,
+          flume.progress.indexes.target
+        )
+        t.end()
+      }, 200)
     }
   })
 
   require('../legacy')(db, flume)
 
 })
-
 


### PR DESCRIPTION
this adds test coverage for migrations, and also the data we need for progress bars.

db. now has a `progress` object, which is a bunch of named items (so far, "migration" and "indexes") then in turn are 3-tuples of `{start: number, current: number, target: number}`
to get the current ratio for a progress bar use `Math.floor(current-start / target-start)` which gives a number that moves between 0 and 1. Obviously target should be greater than start, and it helps if start is also near the first value for current and it's extra nice if the current moves fairly evenly through the number space between start and target, but these things are only advisory. If current eventually ends up at current, we should get a half decent progress bar.

My intention is that other plugins that could make sense to have progress will add things to this object.

I'm gonna merge this as a feature, and then I think we have everything we need to merge flume into scuttlebot!