### PR TITLE
Fix typo in legacy.js

### DIFF
--- a/legacy.js
+++ b/legacy.js
@@ -95,7 +95,7 @@ module.exports = function (db, flumedb) {
           else flumedb.get(v, function (err, data) {
             if(err) throw err
             if(data.timestamp < last.timestamp) {
-              prog = flume.progress.migration = {
+              prog = flumedb.progress.migration = {
                 start: data.timestamp,
                 current: 0,
                 target: +last.timestamp


### PR DESCRIPTION
I suppose this was a typo since there isn't `flume` defined anywhere else in this file. I actually found this as a runtime exception 

```
Log level: notice
RELOAD INDEX: {"version":13,"since":1497014424195}
RELOAD INDEX: undefined
LOAD LINKS SINCE null 0
/usr/src/app/node_modules/secure-scuttlebutt/legacy.js:98
              prog = flume.progress.migration = {
                     ^

ReferenceError: flume is not defined
    at /usr/src/app/node_modules/secure-scuttlebutt/legacy.js:98:22
    at /usr/src/app/node_modules/flumelog-offset/inject.js:66:14
    at /usr/src/app/node_modules/flumelog-offset/frame/recoverable.js:40:11
    at /usr/src/app/node_modules/aligned-block-file/blocks.js:69:11
    at get (/usr/src/app/node_modules/aligned-block-file/blocks.js:25:7)
    at next (/usr/src/app/node_modules/aligned-block-file/blocks.js:48:7)
    at Object.read (/usr/src/app/node_modules/aligned-block-file/blocks.js:72:7)
    at next (/usr/src/app/node_modules/flumelog-offset/frame/recoverable.js:39:16)
    at /usr/src/app/node_modules/flumelog-offset/frame/recoverable.js:35:11
    at /usr/src/app/node_modules/aligned-block-file/blocks.js:91:11
```