### PR TITLE
make work in electron, don't depend on node style setInterval(...).unref

### DIFF
--- a/db.js
+++ b/db.js
@@ -46,9 +46,9 @@ module.exports = function (dir, keys) {
       prog.start = prog.current
   }
 
-  setInterval(update, 200).unref()
+  // unref is only available when running inside node
+  var timer = setInterval(update, 200)
+  timer.unref && timer.unref()
 
   return db
 }
-
-


### PR DESCRIPTION
Currently when you try to use this inside an electron render process you get the following error:

```
TypeError: setInterval(...).unref is not a function
    at module.exports (/Users/matt/Code/patchwork/node_modules/scuttlebot/node_modules/secure-scuttlebutt/db.js:49:28)
    at module.exports (/Users/matt/Code/patchwork/node_modules/scuttlebot/node_modules/secure-scuttlebutt/index.js:51:27)
    at module.exports (/Users/matt/Code/patchwork/node_modules/scuttlebot/node_modules/secure-scuttlebutt/create.js:9:10)
    at Object.init (/Users/matt/Code/patchwork/node_modules/scuttlebot/index.js:48:15)
    at /Users/matt/Code/patchwork/node_modules/secret-stack/api.js:27:28
    at Array.forEach (native)
    at create (/Users/matt/Code/patchwork/node_modules/secret-stack/api.js:26:20)
    at module.exports (/Users/matt/Code/patchwork/server-process.js:24:11)
    at <anonymous>:20:9
    at EventEmitter.electron.ipcRenderer.on (/Users/matt/Code/patchwork/node_modules/electron/dist/Electron.app/Contents/Resources/electron.asar/renderer/init.js:51:28)
```

Since electron must be manually quit anyway, the unref wouldn't be doing anything. This PR makes it only call `unref` if it is available.

cc @dominictarr 