### PR TITLE
Add missing dependency ltgt (used in indexes/last.js)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "level-codec": "^6.2.0",
     "level-peek": "^2.0.1",
     "level-sublevel": "^6.6.0",
+    "ltgt": "^2.2.0",
     "monotonic-timestamp": "~0.0.8",
     "obv": "0.0.1",
     "pull-cat": "~1.1.5",


### PR DESCRIPTION
Tests fail on Node.js 4