### PR TITLE
throw immediately when `db.get` called with a non-ref string

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,10 @@ module.exports = function (_db, opts, keys, path) {
         if(err) cb(err)
         else cb(null, seq && seq.value)
       })
-    else _get(key, cb) //seq
+    else if(typeof key === 'number') 
+      _get(key, cb) //seq
+    else
+      cb(new Error('Invalid key. You must call `get` with with an ssb ref or flume offset'))
   }
 
   var add = Validator(db, opts)


### PR DESCRIPTION
Right now if you call `get('someString')` things get really nasty. The request makes it all the way to https://github.com/flumedb/aligned-block-file/blob/master/blocks.js#L40 before throwing. It's also inside async so the stack trace is lost and you have no idea where the culprit is! (I wasted an hr trying to track down something thanks to this)

**This PR adds a check to ensure that the key is a number before passing it to flume. It throws an error if unhandled.**

_Warning: Code untested! Did this instead of an issue so the fix could be illustrated clearly. Not sure how to word the error message._