### PR TITLE
bump flumedb version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cont": "~1.0.0",
     "deep-equal": "~0.2.1",
     "explain-error": "~1.0.1",
-    "flumedb": "^0.2.3",
+    "flumedb": "^0.3.1",
     "flumelog-offset": "^3.0.2",
     "flumeview-level": "^2.0.1",
     "flumeview-reduce": "^1.0.4",


### PR DESCRIPTION
to bring in the fixes from flumedb/flumedb#7

(this is pre 1.0 so even with the `^`, it is fixed at 0.2.x)

@dominictarr 