### PR TITLE
fix resume migration progress

### DIFF
--- a/legacy.js
+++ b/legacy.js
@@ -111,10 +111,14 @@ module.exports = function (db, flumedb) {
         function migrate () {
           // actual upgrade
           pull(
-            db.createLogStream({gt: since}),
+            db.createLogStream(),
             paramap(function (data, cb) {
               prog.current += 1
-              flumedb.append(data, cb)
+              if (data.timestamp > since) {
+                flumedb.append(data, cb)
+              } else {
+                cb() // skip this one, we already have it!
+              }
             }, 32),
             pull.drain(null, ready)
           )


### PR DESCRIPTION
If you resume from a migration (after quitting sbot midway), progress display restarts at 0, but work resumes from last stop. This means that the progress display appears to stall midway, but it is actually because it's comparing against the total number, not the remaining.

**There is no way to get the remaining number using the fast track count method, so instead this PR starts the migration from `gt: 0` and then skips all of the items before `since`. Now migration appears to resume from where it left off after a fairly quick "catchup"**

I think this small catchup time is worth the trade-off because resuming from migration is not that common and the UX of a stuck progress bar is basically the worst possible thing. 

cc @dominictarr 