### PR TITLE
filter private messages out of into the log stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,23 +184,26 @@ module.exports = function (_db, opts, keys, path) {
 
 
   db.createLogStream = function (opts) {
-    var limit = opts.limit
-    if(limit)
-      delete opts.limit
+    if(opts && opts.raw)
+      return db.stream(opts)
+
     opts = stdopts(opts)
-    if(opts.raw)
-      return db.stream()
+    var limit
+    if('boolean' === typeof opts.private) {
+      limit = opts && opts.limit
+      if(limit) delete opts.limit
+    }
 
     var keys = opts.keys; delete opts.keys
     var values = opts.values; delete opts.values
     return pull(
       db.time.read(opts),
-      pull.filter(function (data) {
+      limit ? pull.filter(function (data) {
         if(data.sync) return true
         var content = data.value.value.content
         if(opts.private == null) return true
         return opts.private === ('string' === typeof content)
-      }),
+      }) : pull.through(),
       limit ? pull.take(limit) : pull.through(),
       Format(keys, values)
     )
@@ -253,4 +256,7 @@ module.exports = function (_db, opts, keys, path) {
   }
   return db
 }
+
+
+
 

--- a/index.js
+++ b/index.js
@@ -89,10 +89,10 @@ module.exports = function (_db, opts, keys, path) {
         if(err) cb(err)
         else cb(null, seq && seq.value)
       })
-    else if(typeof key === 'number') 
+    else if(Number.isInteger(key)) 
       _get(key, cb) //seq
     else
-      cb(new Error('Invalid key. You must call `get` with with an ssb ref or flume offset'))
+      throw new Error('secure-scuttlebutt.get: key *must* be a ssb message id or a flume offset')
   }
 
   var add = Validator(db, opts)

--- a/index.js
+++ b/index.js
@@ -188,7 +188,6 @@ module.exports = function (_db, opts, keys, path) {
     if(limit)
       delete opts.limit
     opts = stdopts(opts)
-    console.log('createLogStream', opts)
     if(opts.raw)
       return db.stream()
 
@@ -254,3 +253,4 @@ module.exports = function (_db, opts, keys, path) {
   }
   return db
 }
+

--- a/index.js
+++ b/index.js
@@ -185,12 +185,23 @@ module.exports = function (_db, opts, keys, path) {
 
   db.createLogStream = function (opts) {
     opts = stdopts(opts)
+    console.log('createLogStream', opts)
     if(opts.raw)
       return db.stream()
 
     var keys = opts.keys; delete opts.keys
     var values = opts.values; delete opts.values
-    return pull(db.time.read(opts), Format(keys, values))
+    return pull(
+      db.time.read(opts),
+      pull.filter(function (data) {
+        if(opts.private === true)
+          return 'string' === typeof data.value.content
+        else if(opts.private === false)
+          return 'string' !== typeof data.value.content
+        return true
+      }),
+      Format(keys, values)
+    )
   }
 
   db.messagesByType = db.links.messagesByType

--- a/index.js
+++ b/index.js
@@ -89,7 +89,10 @@ module.exports = function (_db, opts, keys, path) {
         if(err) cb(err)
         else cb(null, seq && seq.value)
       })
-    else _get(key, cb) //seq
+    else if(typeof key === 'number') 
+      _get(key, cb) //seq
+    else
+      cb(new Error('Invalid key. You must call `get` with with an ssb ref or flume offset'))
   }
 
   var add = Validator(db, opts)

--- a/index.js
+++ b/index.js
@@ -184,6 +184,9 @@ module.exports = function (_db, opts, keys, path) {
 
 
   db.createLogStream = function (opts) {
+    var limit = opts.limit
+    if(limit)
+      delete opts.limit
     opts = stdopts(opts)
     console.log('createLogStream', opts)
     if(opts.raw)
@@ -194,12 +197,12 @@ module.exports = function (_db, opts, keys, path) {
     return pull(
       db.time.read(opts),
       pull.filter(function (data) {
-        if(opts.private === true)
-          return 'string' === typeof data.value.content
-        else if(opts.private === false)
-          return 'string' !== typeof data.value.content
-        return true
+        if(data.sync) return true
+        var content = data.value.value.content
+        if(opts.private == null) return true
+        return opts.private === ('string' === typeof content)
       }),
+      limit ? pull.take(limit) : pull.through(),
       Format(keys, values)
     )
   }
@@ -251,4 +254,3 @@ module.exports = function (_db, opts, keys, path) {
   }
   return db
 }
-

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "flumedb": "^0.2.3",
     "flumelog-offset": "^3.0.2",
     "flumeview-level": "^2.0.1",
-    "flumeview-reduce": "^1.0.4",
+    "flumeview-reduce": "^1.3.1",
     "level": "^1.7.0",
     "level-codec": "^6.2.0",
     "level-peek": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typewiselite": "~1.0.0"
   },
   "scripts": {
-    "prepublish": "npm ls && npm test",
+    "prepublishOnly": "npm ls && npm test",
     "test": "set -e; for t in test/*.js; do node $t; done"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-scuttlebutt",
   "description": "a secure, replicatable database",
-  "version": "16.3.4",
+  "version": "16.3.5",
   "homepage": "https://github.com/ssbc/secure-scuttlebutt",
   "repository": {
     "type": "git",


### PR DESCRIPTION
this simple change makes patchbay@6/minbay approach to private messages work much better. with out this, it loads 2.7 mb of messages on load, with this, only .5