### PR TITLE
use flumeview-hashtable

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "level": "^1.7.0",
     "level-codec": "^6.2.0",
     "level-peek": "^2.0.1",
-    "level-sublevel": "^6.6.0",
+    "level-sublevel": "^6.6.1",
     "ltgt": "^2.2.0",
     "monotonic-timestamp": "~0.0.8",
     "obv": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "explain-error": "~1.0.1",
     "flumedb": "^0.3.1",
     "flumelog-offset": "^3.0.2",
+    "flumeview-hashtable": "^0.1.3",
     "flumeview-level": "^2.0.1",
     "flumeview-reduce": "^1.0.4",
     "level": "^1.7.0",

--- a/related.js
+++ b/related.js
@@ -23,14 +23,15 @@ module.exports = function (db) {
     //which causes messages to be queried twice.
     var n = 1
     var msgs = {key: key, value: null}
+
+    related(msgs, depth)
+
     db.get(key, function (err, msg) {
       msgs.value = msg
       if (err && err.notFound)
         err = null // ignore not found
       done(err)
     })
-
-    related(msgs, depth)
 
     function related (msg, depth) {
       if(depth <= 0) return

--- a/test/migration.js
+++ b/test/migration.js
@@ -100,7 +100,13 @@ tape('progress looks right on empty database', function (t) {
       setTimeout(function () {
         t.equal(
           flume.progress.indexes.current,
-          flume.progress.indexes.target
+          -1,
+          'current is -1'
+        )
+        t.equal(
+          flume.progress.indexes.target,
+          -1,
+          'target is -1'
         )
         t.end()
       }, 200)


### PR DESCRIPTION
replaces flumeview-level with a in memory hashtable! leveldb is slow in the browser, so this is a step towards that (still need to remove the flumeview-level for clock and backlinks)