### PR TITLE
Fix `isFunction`

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function isString (s) {
 }
 
 function isFunction (f) {
-  return 'funciton' == typeof f
+  return 'function' == typeof f
 }
 
 var isArray = Array.isArray

--- a/index.js
+++ b/index.js
@@ -23,16 +23,8 @@ var Format    = u.formatStream
 //53 bit integer
 var MAX_INT  = 0x1fffffffffffff
 
-function isNumber (n) {
-  return typeof n === 'number'
-}
-
 function isString (s) {
   return 'string' === typeof s
-}
-
-function isFunction (f) {
-  return 'function' == typeof f
 }
 
 var isArray = Array.isArray


### PR DESCRIPTION
The `isFunction` function on line 34 in `index.js` is looking for type `funciton` rather than `function. This pull request fixes that error and correctly matches against type `function`. Closes #185 