### PR TITLE
Modify createLogStream in index.js to be createRawLogStream

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = function (_db, opts, keys, path) {
     }
   }
 
-  db.createLogStream = function (opts) {
+  db.createRawLogStream = function (opts) {
     return db.stream(opts)
   }
 


### PR DESCRIPTION
The createLogStream method in index.js is getting overwritten in extras.js, but I would like raw access to the method still, with range control, so I've renamed this one to a new method, so it is accessible.