### PR TITLE
.latest always returns an object

### DIFF
--- a/indexes/last.js
+++ b/indexes/last.js
@@ -30,7 +30,7 @@ module.exports = function () {
       return pCont(function (cb) {
         index.get([], function (err, val) {
           if(err) return cb(err)
-          cb(null, pull.values(Object.keys(val).map(function (author) {
+          cb(null, pull.values(Object.keys(val||{}).map(function (author) {
             return {id: author, sequence: val[author].sequence, ts: val[author].ts}
           })))
         })

--- a/test/latest.js
+++ b/test/latest.js
@@ -24,6 +24,16 @@ var carol = db.createFeed()
 var start = Date.now()
 
 //LEGACY: uses feed.add as a continuable
+tape ('empty', function(t) {
+  cont.para([
+  ])(function (err) {
+    if(err) throw err
+    pull(
+      db.latest(),
+      pull.collect(function (err, ary) {}))
+      t.end()
+  })
+})
 
 tape('latest', function (t) {
 

--- a/test/latest.js
+++ b/test/latest.js
@@ -30,7 +30,9 @@ tape ('empty', function(t) {
     if(err) throw err
     pull(
       db.latest(),
-      pull.collect(function (err, ary) {}))
+      pull.collect(function (err, ary) {
+        t.equal(ary.length, 0)
+      }))
       t.end()
   })
 })


### PR DESCRIPTION
Running `sbot latest` on an idle and empty sbot server causes the server to crash.

```
$ ./bin.js server
Log level: notice
************************************************** (indexes:100%)/home/donp/code/scuttlebot/scuttlebot/node_modules/secure-scuttlebutt/indexes/last.js:33
          cb(null, pull.values(Object.keys(val).map(function (author) {
                                      ^

TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at /home/donp/code/scuttlebot/scuttlebot/node_modules/secure-scuttlebutt/indexes/last.js:33:39
    at Object.get (/home/donp/code/scuttlebot/scuttlebot/node_modules/flumeview-reduce/inject.js:115:11)
    at /home/donp/code/scuttlebot/scuttlebot/node_modules/secure-scuttlebutt/indexes/last.js:31:15
    at /home/donp/code/scuttlebot/scuttlebot/node_modules/pull-cont/index.js:18:5
    at again (/home/donp/code/scuttlebot/scuttlebot/node_modules/pull-cont/index.js:20:41)
    at /home/donp/code/scuttlebot/scuttlebot/node_modules/flumedb/wrap.js:37:31
    at ready (/home/donp/code/scuttlebot/scuttlebot/node_modules/flumedb/wrap.js:24:80)
    at /home/donp/code/scuttlebot/scuttlebot/node_modules/flumedb/wrap.js:37:11
    at /home/donp/code/scuttlebot/scuttlebot/node_modules/pull-cont/index.js:18:5
```

It looks like latest() is not checking for .get to return undefined, which appears to be a valid value when the log is empty. The `|| {}` puts in an empty object in that case.