### PR TITLE
feed index: use resolved timestamp to ensure unwanted items can't get pinned to top of feed

### DIFF
--- a/util.js
+++ b/util.js
@@ -60,7 +60,8 @@ var reboxValue = exports.reboxValue = function (value, isPrivate) {
 var rebox = exports.rebox = function (data, isPrivate) {
   return isPrivate === true ? data : {
     key: data.key, value: reboxValue(data.value, isPrivate),
-    timestamp: data.timestamp
+    timestamp: data.timestamp,
+    rts: data.rts
   }
 }
 


### PR DESCRIPTION
### ⚠️ Because scuttlebutt is a _"they who said somebody should, should"_ project, if nobody complains about this before _19 August_, I will be merging it! 

So please speak up if this is going to break your code 🐵 

@dominictarr @mixmix @evbogue @staltz @soapdog @arj03 @clehner 

---

There is currently a massive problem with `getFeedStream` that basically renders it unusable. It's that if someone posts a message with a timestamp far in the future, it will get permanently stuck at the top of your feed. This limitation means that I haven't been using this index at all, and instead am forced to make my own index.

**This PR solves the problem by indexing `Math.min(msg.timestamp, msg.value.timestamp)` to ensure that a message can never be newer than the time it was synced.** It also adds a new `rts` key to the results (alongside `timestamp`) so that you can easily get this value. This brings `getFeedStream` inline with ssb-backlinks.

Technically this is a breaking change, as clients may be using `msg.value.timestamp` to resume the feed with a stepper (endless scrolling). However, in practice, I don't think that it will break any clients as messages with `value.timestamp > timestamp` are very rare, and the client can easily be fixed by using `msg.rts || msg.value.timestamp`. 

If no one else thinks that this is worth merging (because of the breaking change), I will continue to use my custom index in patchwork (and we'll be left with one more useless legacy index [that no one should use] in scuttlebutt).

Another good talking point might be whether the key should be `rts` or something else. I chose this as that is what `ssb-backlinks` uses.