### PR TITLE
Prevent crash when unboxer throws exception

### DIFF
--- a/minimal.js
+++ b/minimal.js
@@ -18,7 +18,11 @@ var isArray = Array.isArray
 function unbox(data, unboxers) {
   if(data && isString(data.value.content)) {
     for(var i = 0;i < unboxers.length;i++) {
-        var plaintext = unboxers[i](data.value.content, data.value)
+        var plaintext
+        try {
+          plaintext = unboxers[i](data.value.content, data.value)
+        } catch (_) { }
+
         if(plaintext) {
             data.value.cyphertext = data.value.content
             data.value.content = plaintext


### PR DESCRIPTION
This resolves #217 by catching unboxer exceptions and moving on as if nothing happened. This does *not* log uncaught exceptions, and instead leaves that to the unboxer. Please let me know if this needs changes before merging or if we should instead handle this elsewhere. Thanks!