### PR TITLE
Async unboxer

### DIFF
--- a/minimal.js
+++ b/minimal.js
@@ -18,13 +18,10 @@ var isArray = Array.isArray
 function unbox(data, unboxers) {
   if(data && isString(data.value.content)) {
     for(var i = 0;i < unboxers.length;i++) {
-        var plaintext = unboxers[i](data.value.content, data.value)
-        if(plaintext) {
-            data.value.cyphertext = data.value.content
-            data.value.content = plaintext
-            data.value.private = true
-            return data
-        }
+      var plaintext = unboxers[i](data.value)
+      if(plaintext) {
+        data.value = plaintext
+      }
     }
   }
   return data
@@ -57,7 +54,15 @@ module.exports = function (dirname, keys, opts) {
   var hmac_key = opts && opts.caps && opts.caps.sign
 
 
-  var main_unboxer = function(content) { return _unbox(content, keys); }
+  var main_unboxer = function(value) {
+    var plaintext = _unbox(value.content, keys);
+    if (plaintext) {
+      value.cyphertext = value.content
+      value.content = plaintext
+      value.private = true
+    }
+    return value
+  }
   var unboxers = [ main_unboxer ]
 
   var codec = {

--- a/minimal.js
+++ b/minimal.js
@@ -16,15 +16,21 @@ var isFeed = require('ssb-ref').isFeed
 var isArray = Array.isArray
 
 function unbox(data, unboxers) {
-  if(data && isString(data.value.content)) {
-    for(var i = 0;i < unboxers.length;i++) {
-      var plaintext = unboxers[i](data.value)
-      if(plaintext) {
-        data.value = plaintext
-      }
+  // pass results from one unboxer to the next
+  return unboxers.reduce((promises, unboxer) => {
+    return promises.then(previous =>
+      unboxer(data.value).then(result =>
+        [ ...previous, result ]
+      )
+    );
+  }, Promise.resolve([])).then(results => {
+
+    if (results.some(x => x !== false)) {
+      data.value = Object.assign({}, ...results)
     }
-  }
-  return data
+
+    return data
+  });
 }
 
 /*
@@ -53,15 +59,22 @@ function isString (s) {
 module.exports = function (dirname, keys, opts) {
   var hmac_key = opts && opts.caps && opts.caps.sign
 
-
-  var main_unboxer = function(value) {
-    var plaintext = _unbox(value.content, keys);
-    if (plaintext) {
-      value.cyphertext = value.content
-      value.content = plaintext
-      value.private = true
-    }
-    return value
+  var main_unboxer = async function(value) {
+    return new Promise(function (resolve) {
+      if (isString(value.content)) {
+        var plaintext = _unbox(value.content, keys);
+        if (plaintext) {
+          value.cyphertext = value.content
+          value.content = plaintext
+          value.private = true
+          resolve(value)
+        } else {
+          resolve(false)
+        }
+      } else {
+        resolve(false)
+      }
+    })
   }
   var unboxers = [ main_unboxer ]
 


### PR DESCRIPTION
This PR depends on [asynchronous codecs](https://github.com/flumedb/flumelog-offset/pull/14) and makes a few changes to allow asynchronous unboxers:

- Unboxers get passed `value` rather than `content, value`
  - This allows unboxers to set props like `private: true`
  - Unboxers can use `value.content` rather than a dedicated `content` argument
- Unboxers are currently required to be `async function`s that return promises
  - I don't have any strong opinions on this, it was just the most consistent implementation.
  - These promises are processed in a chain, where one unboxer's result is passed to the next
  - This allows for combinations like `main_unboxer(blob_unboxer(value))`
- Unboxers return `false` to indicate that they don't want to process a value
  - This *shouldn't* conflict with any other values, unless an unboxer wants to return `content: false`
  - The performance gains are probably trivial, but this means we're only returning `value` when necessary

I'm sure this will be the first of a few iterations, please let me know if you have any suggestions or see any pain points that we should try to avoid. Thanks for taking a look!