### PR TITLE
pass a unbox key to a private message

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,13 +65,15 @@ module.exports = function (_db, opts, keys, path) {
   var _get = db.get
 
   db.get = function (key, cb) {
-    var isPrivate = false
+    var isPrivate = false, unbox
     if('object' === typeof key) {
       isPrivate = key.private === true
+      unbox = key.unbox
       key = key.id
     }
     if(ref.isMsg(key))
       return db.keys.get(key, function (err, data) {
+        if(isPrivate && unbox) data = db.unbox(data, unbox)
         if(err) cb(err)
         else cb(null, data && u.reboxValue(data.value, isPrivate))
       })
@@ -174,3 +176,4 @@ module.exports = function (_db, opts, keys, path) {
   }
   return db
 }
+

--- a/minimal.js
+++ b/minimal.js
@@ -204,6 +204,10 @@ module.exports = function (dirname, keys, opts) {
     unboxers.push(unboxer);
   }
 
+  db.unbox = function (data, key) {
+    return unbox(data, unboxers, key)
+  }
+
   return db
 }
 

--- a/minimal.js
+++ b/minimal.js
@@ -32,11 +32,15 @@ function unbox(data, unboxers, key) {
           plaintext = unbox.value(data.value.content, key)
 
         if(plaintext) {
-            data.value.cyphertext = data.value.content
-            data.value.content = plaintext
-            data.value.unbox = key.toString('base64')
-            data.value.private = true
-            return data
+            var msg = {}
+            for(var k in data.value)
+              msg[k] = data.value[k]
+
+            msg.cyphertext = data.value.content
+            msg.content = plaintext
+            msg.unbox = key.toString('base64')
+            msg.private = true
+            return {key: data.key, value: msg, timestamp: data.timestamp}
         }
     }
   }
@@ -69,11 +73,11 @@ function isString (s) {
 module.exports = function (dirname, keys, opts) {
   var hmac_key = opts && opts.caps && opts.caps.sign
 
-
   var main_unboxer = {
     key: function (content) { return ssbKeys.unboxKey(content, keys) },
     value: function (content, key) { return ssbKeys.unboxBody(content, key) }
   }
+
   var unboxers = [ main_unboxer ]
 
   var codec = {

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -49,6 +49,7 @@ module.exports = function (opts) {
           var pmsg = ssb.unbox(ary[0])
           t.notOk(msg.unbox, 'did not mutate original message')
           var unbox_key = pmsg.value.unbox
+          t.equal(typeof unbox_key, 'string')
           t.ok(pmsg)
           t.deepEqual(pmsg.value.content, content2)
 

--- a/util.js
+++ b/util.js
@@ -50,7 +50,7 @@ var reboxValue = exports.reboxValue = function (value, isPrivate) {
   for (var key in value) {
     if (key == 'content')
       o[key] = value.cyphertext || value.content
-    else if (key != 'cyphertext' && key != 'private')
+    else if (key != 'cyphertext' && key != 'private' && key != 'unbox')
       o[key] = value[key]
   }
 


### PR DESCRIPTION
This change is an essential step in the long awaited private groups. it builds on quite a bit of work that has lead up to this, such as [passing decrypted messages to indexes](https://github.com/ssbc/secure-scuttlebutt/pull/199) and the api designed for [encrypted blobs](https://github.com/ssbc/ssb-ws/pull/9)

With this change, you decrypted private messages return an `unbox` key. This is the access code to that message. If someone has that key, they can decrypt that message! This is useful for private-groups because the point is to be able to add people to groups later. It is also a possibility that has always existed, since ssb uses on-the-record encryption. This ability _may_ be suprising for some people, which is why I want to be really explicit about it.

for example:

```
{
 "key": "%WgVG9T2IryRoPMCQk7znuMt2Cmo/shgnrbn0wY6gc3M=.sha256",
  "value": {
    "previous": "%A5UZIu79w7nKxcyNGipFpgNcr/zBMCXR4FnFE/+6+Tc=.sha256",
    "sequence": 13114,
    "author": "@EMovhfIrFk4NihAKnRNhrfRaqIhBv1Wj8pTxJNgvCCY=.ed25519",
    "timestamp": 1525572452307,
    "hash": "sha256",
    "content": {
       //NOT POSTED ON GITHUB. 
    },
    "signature": "FqA/2stQgQpZCXitaVW3+MO/zDtbNWcqqJN7TEkipfpS9zLuj3GW1iY005SRVImzPkR8O1zSLOwdenb1C4UeCQ==.sig.ed25519",
    "cyphertext": "Kmf+xC/d3l9FbHofMjBsjDvTGdlc2dHIbsWBscCQXuGGAUSCKnJtSFiFhM5NyZvq1MaoViEL7mqOZ1f/GrDKa0JTNOZynakv4qPhmq92RDcRlqsF05e+py6clNPDh4RAcizTHCx7FFMx9zjIVY9LlKah/nDEE1U5SWHS7SGrDlvUGlLY3gV+vKHJpAw+xJUchNMOgvLZjultv5nCbesNdEDJJK543/dJrjLDveLQO960ufhg3k4FzKl2fY2opiO6PfS8wEVAh42QIJ+0g6yfPLKTm1jxRTdNgyD32toS6yp3wF6ac7PonEOWIIFEUtrjumsU+xxJ96GVR2mwk6zIMDp1I1hKUFCWskIDtBfMaSCZ9Z8+dOunXI5F0HB7VPKcddwEkdnMKN4idIxAvSUknBaVJes0noFvbjt2aKseP23a/7v2ggSzZz3a3qoafsVJhtpt+LEFjUaH4LnAvGY5/Dgiub+tn0MKMFc570ndq40uIaV1JvvYCCuQkjNjE8ECr+ryYIgyBDq1aS8WJzThQ0yJvYz1Px8IEBvEyqrkGkrI3E0tZvs1DzZ8el1aTrXiOY7hMNmCVES9SU3an+qKFEfAHHuHAbjTOw8u2tTHtVNJkOAb+s0n1pJwpUJlarYy2kRCgyJ3OeZwuYHoXTYqT0roioQZbpgGwngP6H39oXjFzG/VKAfX1mNWLI42GaDEFqCXVXuj9dxkvKgXmmptDw9ERY9rXTfl7akzdSZfBV8unVbcvGH5T78FdRiMjINlLXfEw5HT1xNEeleZbtPnEf6nukTbKcg0Ym9egebY6w+69gMRJ09CnAcmuoghj253hUIuRoI9KMXRU9HMPc19hT+M1AdFAQp6a01wOGKYcaycbsAAeJ0do6wTGdWMG+sxSiwH7yPinPj1ZnBghZPfPMC0fxIsRz/Ry6trGeTzeyWJNjz8PlAiLDZSaQf0GnVC0x0yqPDDTFq14D/c6kk6SVVxfpnKBTlUKr8EW7GWVMERxI1wTmGO519el8KKNSv9eJajuCkNTi9wjqePtbpLsw1uWJ0fyRAMj5HP9xO4ZFKmVnyEZiyjLh2VmbWTtaoVFhnbcrPOY//Cd0BFcU8kQRZXqrZhYUnGndQwkwd89VVlm2n6vDpw0CsKtUXh4Aj7RnSYcVZGAgmj9Fo7nz6hbdRm8VY65eCpmVBOdY9ObOccHr50T5zBjNrjgx4+nQ0SUuVoWvwZDzWcIeaBQsmj83VdOcKGK+xJ5BXSKIbMoBLXtCXjCy+AE9/AZxMwi7McvOSrS2W4Fq+8o4N4zZ1ak76jJQkDQJAUXaGgaZBPU9sZfuEg2LIiK4eZFdGVYWec0MSL4ZqjyUxSiUZTvgQnM6wxzjvh9rhGY6iweoUrUtFLfRbLnoBt246SDjsD2G9UJ+WGqrnuMbE1Fa7EpkbXmfSIsOJLaCY80qJ91edWAkmzh85mAwl/iidc12Bqoyxd+9T2dPNEC/cpy8nakjBBOywlShC/ooeXx/4fJ8+A458XlVhni6/hsUevyYMmdoX7jVjoFJxVA2VSlHOFqBBRWUm7tf3IeDlrLe3LyLzjL2s8sofRRSlkIbIENK2Xten7JudP8xjSQOk4o9VyY/ATUmEPA+82hILLD77GiyYV9cy6TPDpOtsBwBvNqDklEi3mRfsffJnwZIp3G+TPo25iVg2IpchMxZ2Ry4VfMXkNOa4NiOAwsAPiONM/8gO7DnHSS74FDICffKWfgC3dKaVs2nOrsyioPBvKiLa1ieSiFxdWXjuKTYN32wWIUk4QX1MI2qvRzH+AL8uWfkA7XhT+SSEc0JGncr8o4KEZtYedZzaGoYt9fwt7kh0vhlaphDYx+7ZtlJvBGlo+FE3w1zX9x5+B7gJJVFriz3S8.box",
    "unbox": "AZlrtZIJQiHqgwCaB0GgtIiFXha+XN5y6n5NJz/HtunP",
    "private": true
  }
}
```
if you are using this PR, and take that `unbox` key, you can do:
```
sbot get --private --id  %WgVG9T2IryRoPMCQk7znuMt2Cmo/shgnrbn0wY6gc3M=.sha256 --unbox AZlrtZIJQiHqgwCaB0GgtIiFXha+XN5y6n5NJz/HtunP 
```
and you'll see the plaintext.