### PR TITLE
Bump ssb-keys to 7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "pull-notify": "^0.1.0",
     "pull-paramap": "^1.1.6",
     "pull-stream": "^3.4.0",
-    "ssb-keys": "^7.0.15",
+    "ssb-keys": "^7.1.0",
     "ssb-msgs": "^5.0.0",
     "ssb-ref": "^2.12.0",
     "ssb-validate": "^3.0.1",


### PR DESCRIPTION
#220 depends on a newer version of ssb-keys, so running `npm install && npm test` results in:

```
TypeError: ssbKeys.unboxKey is not a function
    at Object.key (/home/christianbundy/src/secure-scuttlebutt/minimal.js:77:46)
    at unbox (/home/christianbundy/src/secure-scuttlebutt/minimal.js:28:23)
    at Object.decode (/home/christianbundy/src/secure-scuttlebutt/minimal.js:88:14)
    at /home/christianbundy/src/secure-scuttlebutt/node_modules/flumelog-offset/inject.js:46:27
    at /home/christianbundy/src/secure-scuttlebutt/node_modules/flumelog-offset/frame/recoverable.js:48:11
    at /home/christianbundy/src/secure-scuttlebutt/node_modules/aligned-block-file/blocks.js:74:11
    at get (/home/christianbundy/src/secure-scuttlebutt/node_modules/aligned-block-file/blocks.js:29:7)
    at next (/home/christianbundy/src/secure-scuttlebutt/node_modules/aligned-block-file/blocks.js:53:7)
    at Object.read (/home/christianbundy/src/secure-scuttlebutt/node_modules/aligned-block-file/blocks.js:77:7)
    at next (/home/christianbundy/src/secure-scuttlebutt/node_modules/flumelog-offset/frame/recoverable.js:47:16)
npm ERR! Test failed.  See above for more details.
```

This PR corrects the dependency problem and passes `npm test`.