### PR TITLE
Add `addMap()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,33 @@ If `opts.meta` is unset (default: true) `source, hash, rel` will be left off.
 > have to scan all the links from source, and then filter by dest.
 > your query will be more efficient if you also provide `rel`.
 
+### SecureScuttlebutt#addMap (fn)
+
+Add a map function to be applied to all messages on *read*. The `fn` function
+is should expect `(val, cb)`, and must eventually call `cb(err, val)` to finish.
+
+These modifications only change the value being read, but the underlying data is
+never modified. If multiple map functions are added, they are called serially and
+the `val` output by one map function is passed as the input `val` to the next.
+
+
+```js
+SecureScuttlebutt.addMap(function (val, cb) {
+  if (val.timestamp % 3 === 0)
+    val.fizz = true
+  if (val.timestamp % 5 === 0)
+    val.buzz = true
+  cb(null, val)
+})
+
+SecureScuttlebutt.addMap(function (val, cb) {
+  // This could instead go in the first map function, but it's added as a second
+  // function for demonstration purposes to show that `val` is passed serially.
+  if (val.fizz && val.buzz)
+    val.fizzBuzz = true
+  cb(null, val)
+})
+```
 
 ## Stability
 

--- a/minimal.js
+++ b/minimal.js
@@ -108,7 +108,7 @@ module.exports = function (dirname, keys, opts) {
 
   //NOTE: must use db.ready.set(true) at when migration is complete
   //false says the database is not ready yet!
-  var db = Flume(log, false, maps ? chainMaps : null)
+  var db = Flume(log, false, maps.length ? chainMaps : null)
   .use('last', require('./indexes/last')())
 
   var state = V.initial(), ready = false

--- a/minimal.js
+++ b/minimal.js
@@ -93,9 +93,22 @@ module.exports = function (dirname, keys, opts) {
 
   var log = OffsetLog(path.join(dirname, 'log.offset'), {blockSize:1024*16, codec:codec})
 
-  //NOTE: must use db.ready.set(true) at when migration is complete
+  const maps = []
+  const chainMaps = (val, cb) => {
+    let idx = -1 // haven't entered the chain yet
+    const next = (err, val) => {
+      idx += 1
+      if (err || idx === maps.length)
+        cb(err, val)
+      else
+        maps[idx](val, next)
+    }
+    next(null, val)
+  }
 
-  var db = Flume(log, false, opts.map) //false says the database is not ready yet!
+  //NOTE: must use db.ready.set(true) at when migration is complete
+  //false says the database is not ready yet!
+  var db = Flume(log, false, maps ? chainMaps : null)
   .use('last', require('./indexes/last')())
 
   var state = V.initial(), ready = false
@@ -210,6 +223,9 @@ module.exports = function (dirname, keys, opts) {
 
   db.unbox = function (data, key) {
     return unbox(data, unboxers, key)
+  }
+  db.addMap = function(fn) {
+    maps.push(fn);
   }
 
   return db

--- a/minimal.js
+++ b/minimal.js
@@ -95,17 +95,22 @@ module.exports = function (dirname, keys, opts) {
 
   const maps = []
   const chainMaps = (val, cb) => {
-    if (!maps.length) return cb(null, val)
-
-    let idx = -1 // haven't entered the chain yet
-    const next = (err, val) => {
-      idx += 1
-      if (err || idx === maps.length)
-        cb(err, val)
-      else
-        maps[idx](val, next)
+    const mapCount = maps.length
+    if (!mapCount) {
+      return cb(null, val)
+    } else if (mapCount === 1) {
+      maps[0](val, cb)
+    } else {
+      let idx = -1 // haven't entered the chain yet
+      const next = (err, val) => {
+        idx += 1
+        if (err || idx === maps.length)
+          cb(err, val)
+        else
+          maps[idx](val, next)
+      }
+      next(null, val)
     }
-    next(null, val)
   }
 
   //NOTE: must use db.ready.set(true) at when migration is complete

--- a/minimal.js
+++ b/minimal.js
@@ -95,7 +95,7 @@ module.exports = function (dirname, keys, opts) {
 
   //NOTE: must use db.ready.set(true) at when migration is complete
 
-  var db = Flume(log, false) //false says the database is not ready yet!
+  var db = Flume(log, false, opts.map) //false says the database is not ready yet!
   .use('last', require('./indexes/last')())
 
   var state = V.initial(), ready = false

--- a/minimal.js
+++ b/minimal.js
@@ -95,6 +95,8 @@ module.exports = function (dirname, keys, opts) {
 
   const maps = []
   const chainMaps = (val, cb) => {
+    if (!maps.length) return cb(null, val)
+
     let idx = -1 // haven't entered the chain yet
     const next = (err, val) => {
       idx += 1
@@ -108,7 +110,7 @@ module.exports = function (dirname, keys, opts) {
 
   //NOTE: must use db.ready.set(true) at when migration is complete
   //false says the database is not ready yet!
-  var db = Flume(log, false, maps.length ? chainMaps : null)
+  var db = Flume(log, false, chainMaps)
   .use('last', require('./indexes/last')())
 
   var state = V.initial(), ready = false


### PR DESCRIPTION
I'm working toward using the flumedb map as a Scuttlebot plugin, but it seems like the first step would be to accept a function as `opts.map` that gets passed to flume. Is this the best way to go about that change?

Backlink: https://github.com/flumedb/flumedb/pull/19.