### PR TITLE
Reuse hash of message instead of recomputing it

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,5 +1,4 @@
 var path = require('path')
-var ViewLevel = require('flumeview-level')
 var ViewHashTable = require('flumeview-hashtable')
 
 module.exports = function (dir, keys, opts) {

--- a/index.js
+++ b/index.js
@@ -158,7 +158,6 @@ module.exports = function (_db, opts, keys, path) {
         clock[k] = h[k].sequence
       cb(null, clock)
     })
-
   }
 
   if(_db) {
@@ -175,10 +174,9 @@ module.exports = function (_db, opts, keys, path) {
         if(--n) return
         cb()
       }
-
     }
-
   }
+
   return db
 }
 

--- a/indexes/last.js
+++ b/indexes/last.js
@@ -3,8 +3,8 @@ var path = require('path')
 var ltgt = require('ltgt')
 var u = require('../util')
 var pCont = require('pull-cont')
-//var ViewLevel = require('flumeview-level')
 var Reduce = require('flumeview-reduce')
+
 function isNumber (n) {
   return typeof n === 'number'
 }
@@ -15,7 +15,6 @@ function toSeq (latest) {
 
 module.exports = function () {
 
-  //TODO: rewrite as a flumeview-reduce
   var createIndex = Reduce(1, function (acc, data) {
     if(!acc) acc = {}
     acc[data.value.author] = {id: data.key, sequence: data.value.sequence, ts: data.value.timestamp}
@@ -38,12 +37,5 @@ module.exports = function () {
     }
 
     return index
-
   }
 }
-
-
-
-
-
-

--- a/minimal.js
+++ b/minimal.js
@@ -20,7 +20,7 @@ function unbox(data, unboxers, key) {
   var plaintext
   if(data && isString(data.value.content)) {
     for(var i = 0;i < unboxers.length;i++) {
-      var unbox = unboxers[i], value
+      var unbox = unboxers[i]
       if(isFunction(unbox)) {
         plaintext = unbox(data.value.content, data.value)
       }


### PR DESCRIPTION
This reuses the id of ssb-validates append instead of recomputing it. On my machine this saves 5 seconds out of 157 seconds for benchmark 11 in bench-ssb.