### PR TITLE
Use addMap for unboxer

### DIFF
--- a/codec.js
+++ b/codec.js
@@ -5,6 +5,7 @@ module.exports = {
   encode: function (obj) {
     return JSON.stringify(obj, null, 2)
   },
-  buffer: false
+  buffer: false,
+  type: 'ssb'
 }
 

--- a/minimal.js
+++ b/minimal.js
@@ -93,13 +93,8 @@ module.exports = function (dirname, keys, opts) {
 
   var log = OffsetLog(path.join(dirname, 'log.offset'), {blockSize:1024*16, codec:codec})
 
-  const unboxerMap = (data, cb) => {
-    data = db.unbox(data)
-    cb(null, data)
-  }
-
+  const unboxerMap = (msg, cb) => cb(null, db.unbox(msg))
   const maps = [ unboxerMap ]
-
   const chainMaps = (val, cb) => {
     // assumes `maps.length >= 1`
     if (maps.length === 1) {

--- a/minimal.js
+++ b/minimal.js
@@ -85,7 +85,7 @@ module.exports = function (dirname, keys, opts) {
       return JSON.stringify(obj, null, 2)
     },
     decode: function (str) {
-      return unbox(JSON.parse(str.toString()), unboxers)
+      return JSON.parse(str.toString())
     },
     buffer: false,
     type: 'ssb'
@@ -93,12 +93,16 @@ module.exports = function (dirname, keys, opts) {
 
   var log = OffsetLog(path.join(dirname, 'log.offset'), {blockSize:1024*16, codec:codec})
 
-  const maps = []
+  const unboxerMap = (data, cb) => {
+    data = db.unbox(data)
+    cb(null, data)
+  }
+
+  const maps = [ unboxerMap ]
+
   const chainMaps = (val, cb) => {
-    const mapCount = maps.length
-    if (!mapCount) {
-      return cb(null, val)
-    } else if (mapCount === 1) {
+    // assumes `maps.length >= 1`
+    if (maps.length === 1) {
       maps[0](val, cb)
     } else {
       let idx = -1 // haven't entered the chain yet

--- a/minimal.js
+++ b/minimal.js
@@ -2,7 +2,7 @@
 var path = require('path')
 var Flume = require('flumedb')
 var OffsetLog = require('flumelog-offset')
-//var codec = require('flumecodec/json')
+var codec = require('./codec')
 var AsyncWrite = require('async-write')
 var V = require('ssb-validate')
 var timestamp = require('monotonic-timestamp')
@@ -80,18 +80,7 @@ module.exports = function (dirname, keys, opts) {
 
   var unboxers = [ main_unboxer ]
 
-  var codec = {
-    encode: function (obj) {
-      return JSON.stringify(obj, null, 2)
-    },
-    decode: function (str) {
-      return JSON.parse(str.toString())
-    },
-    buffer: false,
-    type: 'ssb'
-  }
-
-  var log = OffsetLog(path.join(dirname, 'log.offset'), {blockSize:1024*16, codec:codec})
+  var log = OffsetLog(path.join(dirname, 'log.offset'), { blockSize: 1024*16, codec })
 
   const unboxerMap = (msg, cb) => cb(null, db.unbox(msg))
   const maps = [ unboxerMap ]


### PR DESCRIPTION
This moves the unboxer out of the codec and instead uses a flumedb map. I've benchmarked the performance with bench-ssb and it looks like it's about the same, if not faster:


Original (mean 19.2168 s):

```
random-read 1000000 0 51902.21622463279 19.267
random-read 1000000 0 54585.152838427945 18.32
random-read 1000000 0 51690.27189083015 19.346
random-read 1000000 0 52143.08061320263 19.178
random-read 1000000 0 50080.1282051282 19.968
random-read 1000000 0 49558.9255624938 20.178
random-read 1000000 0 53844.497092397156 18.572
random-read 1000000 0 52298.51995188536 19.121
random-read 1000000 0 51759.83436853002 19.32
random-read 1000000 0 52915.65244999471 18.898
```

This PR (mean 18.9561 s):

```
random-read 1000000 0 51263.64894653201 19.507
random-read 1000000 0 52004.7844401685 19.229
random-read 1000000 0 53844.497092397156 18.572
random-read 1000000 0 53002.597127259236 18.867
random-read 1000000 0 52058.930709563225 19.209
random-read 1000000 0 52681.48772521336 18.982
random-read 1000000 0 53748.99220639613 18.605
random-read 1000000 0 52952.078369075985 18.885
random-read 1000000 0 53245.301102177735 18.781
random-read 1000000 0 52842.9507503699 18.924
```

According to this, the original took 1% longer, but since the benchmark doesn't seem to be testing much unbox-specific code I'm thinking this is probably not relevant. On the other hand, this may be slightly faster when adding more maps since we never need to check for `maps.length === 0`.