### PR TITLE
Add `node_modules` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Been burned by this one too many times and I can't think of a reason not to add it.