### PR TITLE
Add config for Stale app

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
This adds a config for [Stale](https://github.com/apps/stale), which I'll enable for this repo if/when this PR is merged. I've used the default config, the only change being that I've replaced "wontfix" with "stale" and made a label for it. After 60 days the bot will comment, warning that the issue will soon be closed, and unless there's activity within 7 days the issue will close. I'm happy to change any of the config options, feel free to push to the branch.