### PR TITLE
Wait 100ms before writing instead of 10ms

### DIFF
--- a/minimal.js
+++ b/minimal.js
@@ -140,7 +140,7 @@ module.exports = function (dirname, keys, opts) {
     return state.queue.length > 1000
   }, function isEmpty (_state) {
     return !state.queue.length
-  }, 10)
+  }, 100)
 
   queue.onDrain = function () {
     if(state.queue.length == 0) {


### PR DESCRIPTION
I was testing 05-ssb-legacy write to see where the time goes. Comparing with 01 validate I get validate: 53s, write + validate (05) 125s. Seems rather high for 42mb data. Looking around I found the async-write function that defaults to delay write 100 ms, but for some reason it set to 10ms in secure-scuttlebutt. Changing it to 100 ms makes a large difference. 15 seconds!