### PR TITLE
fix: avoid overflow error when computing overall progress

### DIFF
--- a/db.js
+++ b/db.js
@@ -27,7 +27,8 @@ module.exports = function db (dir, keys, opts) {
       var c = db.views[name].since.value
       current += (Number.isInteger(c) ? c : -1)
     }
-    prog.current = ~~(current / n)
+    // we use Math.floor to avoid overflow errors
+    prog.current = Math.floor(current / n)
     // if the progress bar is complete, move the starting point
     // up to the current position!
     if (prog.start <= 0) {


### PR DESCRIPTION
Hello. In good old ssb fashion I'm necro-PR'ing this. :)


This is a fix for a lock-up for the user if the offset log goes beyond 2^31 bytes in length. Since the `~~` uses a (signed) int32 representation, it produces a negative number in these cases. Result: the `progress.indexes.current` value is negative, thus smaller than the `progress.indexes.target` value, and Patchwork refuses to produce any further messages.